### PR TITLE
Implement translation for disclaimer text

### DIFF
--- a/conf/messages.properties
+++ b/conf/messages.properties
@@ -2,3 +2,4 @@ InC-OW-EU = More information about the Work may be found in the following entry 
 NoC-NC = The limitations on commercial use of this item will expire on {0}
 NoC-CR = More information about the contractual restrictions can be found here: <a href="{0}" target="_blank">{0}</a>
 NoC-OKLR = More information about the legal restrictions can be found here: <a href="{0}" target="_blank">{0}</a>
+Disclaimer = The purpose of this statement is to help the public understand how this Item may be used. When there is a (non-standard) License or contract that governs re-use of the associated Item, this statement only summarizes the effects of some of its terms. It is not a License, and should not be used to license your Work. To license your own Work, use a License offered at <a href="http://creativecommons.org/">http://creativecommons.org/</a>

--- a/conf/messages_nl.properties
+++ b/conf/messages_nl.properties
@@ -2,3 +2,4 @@ InC-OW-EU = Meer informatie over het werk kan worden gevonden in de volgende ver
 NoC-NC = De beperkingen voor de commerciele aanwending van dit punt zal aflopen op {0}
 NoC-CR = Meer informatie over de contractuele beperkingen is hier te vinden {0}
 NoC-OKLR = Meer informatie over de wettelijke beperkingen is hier te vinden {0}
+Disclaimer = Het doel van deze verklaring is om te helpen het publiek te begrijpen hoe deze post mogen worden gebruikt. Wanneer er sprake is van een (niet-standaard) licentie of contract dat hergebruik van het bijbehorende punt betreft, deze uitspraak vat alleen de effecten van sommige van haar voorwaarden. Het is niet een licentie, en mag niet worden gebruikt om uw werkvergunning. Om uw eigen werkvergunning, gebruik dan een licentie aangeboden op <a href="http://creativecommons.org/">http://creativecommons.org/</a>

--- a/public/handlebars/statement.hbs
+++ b/public/handlebars/statement.hbs
@@ -5,9 +5,11 @@
 {{> table.hbs data}}
 
 {{#parameters.date}}
-    {{i18n data.identifier . locale=language}}
+    <p>{{i18n data.identifier . locale=language}}</p>
 {{/parameters.date}}
 
 {{#parameters.relatedURL}}
-    {{{i18n data.identifier . locale=language}}}
+    <p>{{{i18n data.identifier . locale=language}}}</p>
 {{/parameters.relatedURL}}
+
+<p>{{{i18n "Disclaimer" locale=language}}}</p>

--- a/test/resources/page/InC/1.0
+++ b/test/resources/page/InC/1.0
@@ -188,6 +188,9 @@
 
 
 
+
+<p>The purpose of this statement is to help the public understand how this Item may be used. When there is a (non-standard) License or contract that governs re-use of the associated Item, this statement only summarizes the effects of some of its terms. It is not a License, and should not be used to license your Work. To license your own Work, use a License offered at <a href="http://creativecommons.org/">http://creativecommons.org/</a></p>
+
         </div>
 
     </body>


### PR DESCRIPTION
On dev, see e.g. http://h2481931.stratoserver.net:9001/page/InC-OW-EU/1.0/?language=en&relatedURL=http://example.org or http://h2481931.stratoserver.net:9001/page/NoC-NC/1.0/?language=nl&date=2016-03-09.

@mzeinstra I added a Dutch Google translation for demonstration purposes.

Fixes #43 