### PR TITLE
Single quote escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ and visit [http://localhost:9000](http://localhost:9000).
 
 [Transifex](https://www.transifex.com/graphthinking-gmbh/rightsstatementsorg/) is used to carry out translations of the app. The relevant resource is tagged with the category `rights-app`. Please get in touch with the [maintainers](https://www.transifex.com/graphthinking-gmbh/rightsstatementsorg/settings/maintainers/) to add a new language to the project.
 
-To incorporate updates or new translations, install [`tx`](https://docs.transifex.com/client/introduction), run [`tx pull`](https://docs.transifex.com/client/pull#command-options)` && for f in conf/messages_*.properties; do native2ascii $f $f; done` and commit the changes. For convenience, you can also execute `./updateI18n.sh` instead. If a new translation has been added, enable it by editing the `languages.available` key in `conf/application.conf`.
+To incorporate updates or new translations, install [`tx`](https://docs.transifex.com/client/introduction). Unicode-only characters in the translated strings will need to be converted to ASCII for the application to support them. Also, single quotes will need to be escaped. For convenience, the [`updateI18n.sh` script](updateI18n.sh) performs this functionality for you. Arguments provided to the script are passed to [`tx pull`](https://docs.transifex.com/client/pull#command-options). To update every language, you can execute
+
+    $ ./updateI18n.sh -f -a
+
+and to add or update specific languages, you can separate them with commas, like so:
+
+    $ ./updateI18n.sh -f -l fr,it
+
+If a new translation has been added, enable it by editing the `languages.available` key in `conf/application.conf`.
 
 The new version needs to be tagged with git so that it gets recognized as a new release, using a tag that starts with `v` (e.g. `v1.2.7`).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and visit [http://localhost:9000](http://localhost:9000).
 
 ## Implementing translations
 
-[Transifex](https://www.transifex.com/graphthinking-gmbh/rightsstatementsorg/) is used to carry out translations of the app. The relevant resource is tagged with the category `rights-app`. Please get in touch with the [maintainers](https://www.transifex.com/graphthinking-gmbh/rightsstatementsorg/settings/maintainers/) to add a new language to the project.
+[Transifex](https://www.transifex.com/rightsstatements-org/rightsstatementsorg/dashboard/) is used to carry out translations of the app. The relevant resource is tagged with the category `rights-app`. Please get in touch with the [maintainers](https://www.transifex.com/rightsstatements-org/rightsstatementsorg/settings/maintainers/) to add a new language to the project.
 
 To incorporate updates or new translations, install [`tx`](https://docs.transifex.com/client/introduction). Unicode-only characters in the translated strings will need to be converted to ASCII for the application to support them. Also, single quotes will need to be escaped. For convenience, the [`updateI18n.sh` script](updateI18n.sh) performs this functionality for you. Arguments provided to the script are passed to [`tx pull`](https://docs.transifex.com/client/pull#command-options). To update every language, you can execute
 

--- a/conf/messages_it.properties
+++ b/conf/messages_it.properties
@@ -1,8 +1,8 @@
-InC-OW-EU = Maggiori informazioni riguardo all'oggetto sono disponibili nella seguente voce della Banca dati delle Opere Orfane dell'Ue: <a href="{0}" target="_blank">{0}</a>
-NoC-NC = Le limitazioni all'uso commerciale di questo oggetto termineranno il {0}
+InC-OW-EU = Maggiori informazioni riguardo all''oggetto sono disponibili nella seguente voce della Banca dati delle Opere Orfane dell''Ue: <a href="{0}" target="_blank">{0}</a>
+NoC-NC = Le limitazioni all''uso commerciale di questo oggetto termineranno il {0}
 NoC-CR = Maggiori informazioni sulle restrizioni contrattuali sono disponibili qui: <a href="{0}" target="_blank">{0}</a>
 NoC-OKLR = Maggiori informazioni sulle restrizioni legali sono disponibili qui: <a href="{0}" target="_blank">{0}</a>
-Disclaimer = DISCLAIMER Lo scopo di questa dichiarazione \u00e8 di aiutare il pubblico a capire come questo oggetto pu\u00f2 essere utilizzato. Quando esistono una licenza o un contratto (non standard) che disciplinano il riuso dell'oggetto associato, questa dichiarazione riassume solo gli effetti di alcuni dei loro termini. Non \u00e8 una licenza e non deve essere usata per dare in licenza la propria opera. Per concedere in licenza la propria opera, utilizzare una licenza disponibile all'indirizzo <a href="https://creativecommons.org/">https://creativecommons.org/</a>
+Disclaimer = DISCLAIMER Lo scopo di questa dichiarazione \u00e8 di aiutare il pubblico a capire come questo oggetto pu\u00f2 essere utilizzato. Quando esistono una licenza o un contratto (non standard) che disciplinano il riuso dell''oggetto associato, questa dichiarazione riassume solo gli effetti di alcuni dei loro termini. Non \u00e8 una licenza e non deve essere usata per dare in licenza la propria opera. Per concedere in licenza la propria opera, utilizzare una licenza disponibile all''indirizzo <a href="https://creativecommons.org/">https://creativecommons.org/</a>
 notices = Avvisi
 provider = Questa dichiarazione \u00e8 fornita da <a href="http://rightsstatements.org">rightsstatements.org</a>
 URI = URI per questa dichiarazione:

--- a/updateI18n.sh
+++ b/updateI18n.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 
-tx pull -f -a
+tx pull "$@"
 
 for f in conf/messages_*.properties; do
   native2ascii $f $f
+
+  # java.text.MessageFormat uses single quotes to escape patterns that would
+  # otherwise be used for parameter substitutions. To produce a single quote,
+  # you need to escape it with itself.
+  # See https://www.playframework.com/documentation/2.4.x/ScalaI18N#Notes-on-apostrophes
+  sed -i "s/'/''/g" $f
 done
 
-git add conf/messages_*.properties
-git commit -m "Update i18n"
+echo "To commit i18n changes, use:"
+echo ""
+echo " $ git add conf/messages_*.properties"
+echo " $ git commit -m \"Update i18n\""

--- a/updateI18n.sh
+++ b/updateI18n.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# MacOS ships with BSD sed, so ensure we use GNU coretools sed (presume installed by Homebrew or MacPorts)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed=gsed
+else
+  sed=sed
+fi
+
 tx pull "$@"
 
 for f in conf/messages_*.properties; do
@@ -9,7 +16,7 @@ for f in conf/messages_*.properties; do
   # otherwise be used for parameter substitutions. To produce a single quote,
   # you need to escape it with itself.
   # See https://www.playframework.com/documentation/2.4.x/ScalaI18N#Notes-on-apostrophes
-  sed -i "s/'/''/g" $f
+  $sed -i "s/'/''/g" $f
 done
 
 echo "To commit i18n changes, use:"


### PR DESCRIPTION
updateI18n.sh is updated to escape single quotes, as per [the Play Framework documentation](https://www.playframework.com/documentation/2.4.x/ScalaI18N#Notes-on-apostrophes). I've also updated it to accept arguments for `tx pull`, which means that you can use it to only pull the languages you need. I've documented this change in the README.

I've run the app locally and the parameter substitution that was causing a problem earlier appears to be working.